### PR TITLE
Update gemspec

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+#### Unreleased
+* Update gemspec metadata
+
 #### v1.18.5
 * Add tests for rails 7
   > cbeer: https://github.com/sportngin/okcomputer/pull/174
@@ -15,7 +18,7 @@
 
 #### v1.17.2
 * Add Support for Rails 5.2 Migration Check
-  > 	rmm5t: https://github.com/sportngin/okcomputer/pull/147
+  > rmm5t: https://github.com/sportngin/okcomputer/pull/147
 
 #### v1.17.1
 * Check name in CheckCollection#Register

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -6,17 +6,18 @@ require "ok_computer/version"
 authors = {
   "Patrick Byrne" => "code@patrickbyrne.net",
   "Andy Fleener"  => "anfleene@gmail.com",
-  "Chris Arcand"  => "chris@chrisarcand.com"
+  "Chris Arcand"  => "chris@chrisarcand.com",
 }
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  username      = "emmahsax"
   s.name        = "okcomputer"
   s.version     = OkComputer::VERSION
   s.authors     = authors.keys
   s.email       = authors.values
   s.license     = "MIT"
-  s.homepage    = "https://github.com/emmahsax/okcomputer"
+  s.homepage    = "https://github.com/#{username}/#{s.name}"
   s.summary     = "A simple, extensible health-check monitor"
   s.description = %Q(
     Inspired by the simplicity of Fitter Happier, but frustrated by its lack of
@@ -28,8 +29,14 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_development_dependency "sqlite3", "~> 1.3.6"
-  s.add_development_dependency "rspec-rails", "~> 4.0"
+  s.metadata = {
+    "bug_tracker_uri"   => "#{s.homepage}/issues",
+    "changelog_uri"     => "#{s.homepage}/blob/master/CHANGELOG.markdown",
+    "source_code_uri"   => s.homepage,
+  }
+
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "sequel"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
 end

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.authors     = authors.keys
   s.email       = authors.values
   s.license     = "MIT"
-  s.homepage    = "https://github.com/sportngin/okcomputer"
+  s.homepage    = "https://github.com/emmahsax/okcomputer"
   s.summary     = "A simple, extensible health-check monitor"
   s.description = %Q(
     Inspired by the simplicity of Fitter Happier, but frustrated by its lack of

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -7,6 +7,8 @@ authors = {
   "Patrick Byrne" => "code@patrickbyrne.net",
   "Andy Fleener"  => "anfleene@gmail.com",
   "Chris Arcand"  => "chris@chrisarcand.com",
+  "Emma Sax"      => "sax.emma.h@gmail.com",
+  "Ryan McGeary"  => "ryan@mcgeary.org",
 }
 
 # Describe your gem and declare its dependencies:


### PR DESCRIPTION
# What does it do?

- Correct the homepage destination in the gemspec
- Add extra metadata to gemspec
- Add authors to gemspec

# What else?

- [rubygems is pointing at a (now) defunct set of links](https://rubygems.org/gems/okcomputer) for this gem
- i.e. For those trying to find the source from the gem, they hit a dead end.