### PR TITLE
fix libsqlite3-dev install for rails 5.1 and 5.2

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -22,7 +22,7 @@ jobs:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
       - uses: actions/checkout@v4
-      - if: ${{ inputs.rails <= '5.0.0' }}
+      - if: ${{ inputs.rails < '6.0.0' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
fixes #12 

install libsqlite3-dev for all rails versions below 6.0.