### PR TITLE
update migration check to use public active_record methods and errors

### DIFF
--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -2,20 +2,11 @@ module OkComputer
   class ActiveRecordMigrationsCheck < Check
     # Public: Check if migrations are pending or not
     def check
-      # this check is only valid if config.active_record.migration_error
-      # is set to false rather than :page_load
-      # :page_load is the default in development, otherwise this is false
-      if Rails.configuration.active_record.migration_error
-        return mark_message("NO pending migrations") if Rails.env.development?
+      return mark_message(page_load_message) if check_on_page_load?
 
-        return check_on_page_load
-      end
-
-      if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
-        ActiveRecord::Migration.check_all_pending!
-      else
-        ActiveRecord::Migration.check_pending!
-      end
+      # produces ActiveRecord::PendingMigrationError
+      # if pending migrations exist
+      check_pending(Rails.version)
 
       mark_message "NO pending migrations"
     rescue ActiveRecord::PendingMigrationError
@@ -25,10 +16,25 @@ module OkComputer
 
     private
 
-    # We do not fail the check here since this method is only called
-    # when rails is configured to make the check and throw an error
-    def check_on_page_load
-      mark_message "NOTE: pending migrations are checked on page_load"
+    # this check is only valid if config.active_record.migration_error is set to false rather than :page_load
+    # :page_load adds a Middleware check that throws an error before the call reaches ok_computer
+    # we only run this check when :page_load is set if there are no pending migrations
+    # :page_load is the default in development, otherwise this is false
+    # see https://github.com/rails/rails/blob/d39db5d1891f7509cde2efc425c9d69bbb77e670/activerecord/lib/active_record/railtie.rb#L103
+    def check_on_page_load?
+      Rails.configuration.active_record.migration_error
+    end
+
+    def check_pending(version_string)
+      if Gem::Version.new(version_string) >= Gem::Version.new("7.1")
+        ActiveRecord::Migration.check_all_pending!
+      else
+        ActiveRecord::Migration.check_pending!
+      end
+    end
+
+    def page_load_message
+      "NOTE: pending migrations are checked on page_load"
     end
   end
 end

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -4,9 +4,7 @@ module OkComputer
     def check
       return mark_message(page_load_message) if check_on_page_load?
 
-      # produces ActiveRecord::PendingMigrationError
-      # if pending migrations exist
-      check_pending(Rails.version)
+      error_if_pending_migrations(Rails.version)
 
       mark_message "NO pending migrations"
     rescue ActiveRecord::PendingMigrationError
@@ -25,7 +23,7 @@ module OkComputer
       Rails.configuration.active_record.migration_error
     end
 
-    def check_pending(version_string)
+    def error_if_pending_migrations(version_string)
       if Gem::Version.new(version_string) >= Gem::Version.new("7.1")
         ActiveRecord::Migration.check_all_pending!
       else

--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -11,7 +11,7 @@ module OkComputer
         return check_on_page_load
       end
 
-      if Rails.version >= "7.1"
+      if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
         ActiveRecord::Migration.check_all_pending!
       else
         ActiveRecord::Migration.check_pending!

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -2,98 +2,58 @@ require "rails_helper"
 
 module OkComputer
   describe ActiveRecordMigrationsCheck do
+    let(:rails_pending_migration_method) do
+      if Rails.version >= "7.1"
+        # rails now supports multiple databases and checks
+        # that any of them have pending migrations
+        :check_all_pending!
+      else
+        :check_pending!
+      end
+    end
+
     it "is a subclass of Check" do
       expect(subject).to be_a Check
     end
 
-    current_rails_version = Gem::Version.new(ActiveRecord::VERSION::STRING)
-
-    # 4.0 <= Rails < 7.2
-    if current_rails_version >= Gem::Version.new("7.1")
-      # rails now supports multiple databases and checks
-      # that any of them have pending migrations
-
-      context "#check" do
-        before do
-          allow(Rails.configuration.active_record).to receive(:migration_error).and_return(nil)
-        end
-
-        context "with no pending migrations" do
-          before do
-            expect(ActiveRecord::Migration).to receive(:check_all_pending!).and_return(nil)
-          end
-
-          it { is_expected.to be_successful_check }
-          it { is_expected.to have_message "NO pending migrations" }
-        end
-
-        context "with pending migrations" do
-          before do
-            expect(ActiveRecord::Migration).to receive(:check_all_pending!).and_raise(ActiveRecord::PendingMigrationError)
-          end
-
-          it { is_expected.not_to be_successful_check }
-          it { is_expected.to have_message "Pending migrations" }
-        end
-
-        context "when active_record.migration_error set to :page_load" do
-          before do
-            allow(Rails.application.config.active_record).to receive(:migration_error).and_return(:page_load)
-          end
-
-          it { is_expected.to be_successful_check }
-          it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
-
-          context "when in the development env" do
-            before do
-              allow(Rails.env).to receive(:development?).and_return(true)
-            end
-
-            it { is_expected.to be_successful_check }
-            it { is_expected.to have_message "NO pending migrations" }
-          end
-        end
+    context "#check" do
+      before do
+        allow(Rails.configuration.active_record).to receive(:migration_error).and_return(nil)
       end
-    else # Rails < 7.1
-      context "#check" do
+
+      context "with no pending migrations" do
         before do
-          allow(Rails.configuration.active_record).to receive(:migration_error).and_return(nil)
+          expect(ActiveRecord::Migration).to receive(rails_pending_migration_method).and_return(nil)
         end
 
-        context "with no pending migrations" do
+        it { is_expected.to be_successful_check }
+        it { is_expected.to have_message "NO pending migrations" }
+      end
+
+      context "with pending migrations" do
+        before do
+          expect(ActiveRecord::Migration).to receive(rails_pending_migration_method).and_raise(ActiveRecord::PendingMigrationError)
+        end
+
+        it { is_expected.not_to be_successful_check }
+        it { is_expected.to have_message "Pending migrations" }
+      end
+
+      context "when active_record.migration_error set to :page_load" do
+        before do
+          allow(Rails.application.config.active_record).to receive(:migration_error).and_return(:page_load)
+        end
+
+        it { is_expected.to be_successful_check }
+        it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
+
+        context "when in the development env" do
           before do
-            expect(ActiveRecord::Migration).to receive(:check_pending!).and_return(nil)
+            allow(Rails.env).to receive(:development?).and_return(true)
           end
 
           it { is_expected.to be_successful_check }
           it { is_expected.to have_message "NO pending migrations" }
-        end
-
-        context "with pending migrations" do
-          before do
-            expect(ActiveRecord::Migration).to receive(:check_pending!).and_raise(ActiveRecord::PendingMigrationError)
-          end
-
-          it { is_expected.not_to be_successful_check }
-          it { is_expected.to have_message "Pending migrations" }
-        end
-
-        context "when active_record.migration_error set to :page_load" do
-          before do
-            allow(Rails.application.config.active_record).to receive(:migration_error).and_return(:page_load)
-          end
-
-          it { is_expected.to be_successful_check }
-          it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
-
-          context "when in the development env" do
-            before do
-              allow(Rails.env).to receive(:development?).and_return(true)
-            end
-
-            it { is_expected.to be_successful_check }
-            it { is_expected.to have_message "NO pending migrations" }
-          end
         end
       end
     end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module OkComputer
   describe ActiveRecordMigrationsCheck do
     let(:rails_pending_migration_method) do
-      if Rails.version >= "7.1"
+      if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
         # rails now supports multiple databases and checks
         # that any of them have pending migrations
         :check_all_pending!
@@ -32,7 +32,8 @@ module OkComputer
 
       context "with pending migrations" do
         before do
-          expect(ActiveRecord::Migration).to receive(rails_pending_migration_method).and_raise(ActiveRecord::PendingMigrationError)
+          expect(ActiveRecord::Migration)
+            .to receive(rails_pending_migration_method).and_raise(ActiveRecord::PendingMigrationError)
         end
 
         it { is_expected.not_to be_successful_check }
@@ -46,15 +47,6 @@ module OkComputer
 
         it { is_expected.to be_successful_check }
         it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
-
-        context "when in the development env" do
-          before do
-            allow(Rails.env).to receive(:development?).and_return(true)
-          end
-
-          it { is_expected.to be_successful_check }
-          it { is_expected.to have_message "NO pending migrations" }
-        end
       end
     end
   end

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -9,41 +9,91 @@ module OkComputer
     current_rails_version = Gem::Version.new(ActiveRecord::VERSION::STRING)
 
     # 4.0 <= Rails < 7.2
-    if current_rails_version > Gem::Version.new("3.99.99") && current_rails_version < Gem::Version.new("7.2")
-      context "when activerecord supports needs_migration?" do
-        context "#supported?" do
-          it { expect(subject.supported?).to be_truthy }
+    if current_rails_version >= Gem::Version.new("7.1")
+      # rails now supports multiple databases and checks
+      # that any of them have pending migrations
+
+      context "#check" do
+        before do
+          allow(Rails.configuration.active_record).to receive(:migration_error).and_return(nil)
         end
 
-        context "#check" do
-          context "with no pending migrations" do
+        context "with no pending migrations" do
+          before do
+            expect(ActiveRecord::Migration).to receive(:check_all_pending!).and_return(nil)
+          end
+
+          it { is_expected.to be_successful_check }
+          it { is_expected.to have_message "NO pending migrations" }
+        end
+
+        context "with pending migrations" do
+          before do
+            expect(ActiveRecord::Migration).to receive(:check_all_pending!).and_raise(ActiveRecord::PendingMigrationError)
+          end
+
+          it { is_expected.not_to be_successful_check }
+          it { is_expected.to have_message "Pending migrations" }
+        end
+
+        context "when active_record.migration_error set to :page_load" do
+          before do
+            allow(Rails.application.config.active_record).to receive(:migration_error).and_return(:page_load)
+          end
+
+          it { is_expected.to be_successful_check }
+          it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
+
+          context "when in the development env" do
             before do
-              expect(subject).to receive(:needs_migration?).and_return(false)
+              allow(Rails.env).to receive(:development?).and_return(true)
             end
 
             it { is_expected.to be_successful_check }
             it { is_expected.to have_message "NO pending migrations" }
           end
-
-          context "with pending migrations" do
-            before do
-              expect(subject).to receive(:needs_migration?).and_return(true)
-            end
-
-            it { is_expected.not_to be_successful_check }
-            it { is_expected.to have_message "Pending migrations" }
-          end
         end
       end
-    else # Rails <= 3.2
-      context "when on older versions of ActiveRecord" do
-        context "#supported?" do
-          it { expect(subject.supported?).to be_falsey }
+    else # Rails < 7.1
+      context "#check" do
+        before do
+          allow(Rails.configuration.active_record).to receive(:migration_error).and_return(nil)
         end
 
-        context "#check" do
+        context "with no pending migrations" do
+          before do
+            expect(ActiveRecord::Migration).to receive(:check_pending!).and_return(nil)
+          end
+
+          it { is_expected.to be_successful_check }
+          it { is_expected.to have_message "NO pending migrations" }
+        end
+
+        context "with pending migrations" do
+          before do
+            expect(ActiveRecord::Migration).to receive(:check_pending!).and_raise(ActiveRecord::PendingMigrationError)
+          end
+
           it { is_expected.not_to be_successful_check }
-          it { is_expected.to have_message "This version of ActiveRecord does not support checking whether migrations are pending" }
+          it { is_expected.to have_message "Pending migrations" }
+        end
+
+        context "when active_record.migration_error set to :page_load" do
+          before do
+            allow(Rails.application.config.active_record).to receive(:migration_error).and_return(:page_load)
+          end
+
+          it { is_expected.to be_successful_check }
+          it { is_expected.to have_message "NOTE: pending migrations are checked on page_load" }
+
+          context "when in the development env" do
+            before do
+              allow(Rails.env).to receive(:development?).and_return(true)
+            end
+
+            it { is_expected.to be_successful_check }
+            it { is_expected.to have_message "NO pending migrations" }
+          end
         end
       end
     end


### PR DESCRIPTION
This change takes a different approach to checking migrations on the app being checked by ok_computer by using the `ActiveRecord::Migration.check_pending!` or  `.check_all_pending!` methods and properly handling the `ActiveRecord::PendingMigrationError` that could be returned.

This also includes checks that display an info message when rails is configured to check migrations on page load.  The main change here is that OkComputer __no longer fails this check__ for different versions of ActiveRecord.

~Need to refactor tests.~

fixes #11 