### PR TITLE
Add `homepage_uri` to gemspec `metadata`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,8 @@
   > emmahsax: https://github.com/emmahsax/okcomputer/pull/19
 * Add benchmark gem as a dependency.
   > willnet: https://github.com/emmahsax/okcomputer/pull/16
+* Fix homepage link on rubygems
+  > rmm5t: https://github.com/emmahsax/okcomputer/pull/20
 
 #### v1.19.0
 * Update ActiveRecordMigrationsCheck to use public active_record methods and errors

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "benchmark"
 
   s.metadata = {
+    "homepage_uri"      => s.homepage,
     "bug_tracker_uri"   => "#{s.homepage}/issues",
     "changelog_uri"     => "#{s.homepage}/blob/main/CHANGELOG.markdown",
     "source_code_uri"   => s.homepage,


### PR DESCRIPTION
The [rubygems page](https://rubygems.org/gems/okcomputer) still has the old "Homepage" link. 

This change should hopefully fix that by adding [`metadata["homepage_uri"]`](https://guides.rubygems.org/specification-reference/#metadata)

Fixes #17