### PR TITLE
Use `actions/checkout@v6`

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       RAILS_VERSION: ${{ inputs.rails }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - if: ${{ inputs.rails < '6.0.0' }}
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
+*.DS_Store
 *.gem
+._*
 .bundle/
+Gemfile.lock
+coverage
 log/*.log
 pkg/
+spec/dummy/.sass-cache
 spec/dummy/db/*.sqlite3
 spec/dummy/log/*.log
 spec/dummy/tmp/
-spec/dummy/.sass-cache
-coverage
-Gemfile.lock

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,6 @@
 #### Unreleased
+* Use `actions/checkout@v6`
+  > emmahsax: https://github.com/emmahsax/okcomputer/pull/24
 * Replace Ruby 3.5 with Ruby 4.0 in all rspec tests
   > emmahsax: https://github.com/emmahsax/okcomputer/pull/22
 


### PR DESCRIPTION
Use the newest version of `actions/checkout` to get latest updates, functionality, and patches.