### PR TITLE
Rename organization from `emmahsax` to `okcomputer-ruby`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-rails-4:
     name: Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,34 +1,34 @@
 #### Unreleased
 * Use `actions/checkout@v6`
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/24
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/24
 * Replace Ruby 3.5 with Ruby 4.0 in all rspec tests
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/22
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/22
 
 #### v1.19.1
 * Add rspec for higher versions of Ruby and Rails
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/19
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/19
 * Add benchmark gem as a dependency.
-  > willnet: https://github.com/emmahsax/okcomputer/pull/16
+  > willnet: https://github.com/okcomputer-ruby/okcomputer/pull/16
 * Fix homepage link on rubygems
-  > rmm5t: https://github.com/emmahsax/okcomputer/pull/20
+  > rmm5t: https://github.com/okcomputer-ruby/okcomputer/pull/20
 
 #### v1.19.0
 * Update ActiveRecordMigrationsCheck to use public active_record methods and errors
-  > dgarwood: https://github.com/emmahsax/okcomputer/pull/14
+  > dgarwood: https://github.com/okcomputer-ruby/okcomputer/pull/14
 * Add a check for SolidCache
-  > stevenchanin & sidk: https://github.com/emmahsax/okcomputer/pull/15
+  > stevenchanin & sidk: https://github.com/okcomputer-ruby/okcomputer/pull/15
 * Update MIT license copyright holder
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/10
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/10
 * Added `bin/release` script to make it easier to make new version bumps and releases without other tools like soyuz or octopolo
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/8
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/8
 * Fix rspec tests and add testing for higher versions of Ruby/Rails
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/9
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/9
 
 #### v1.18.6
 * Change default branch from `master` to `main`
-  > emmahsax: https://github.com/emmahsax/okcomputer/pull/7
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/7
 * Update gemspec metadata
-  > rmm5t: https://github.com/emmahsax/okcomputer/pull/6
+  > rmm5t: https://github.com/okcomputer-ruby/okcomputer/pull/6
 
 #### v1.18.5
 * Add tests for rails 7
@@ -196,4 +196,4 @@
 #### v1.0.0
 
 * Version bump
-* For prior breaking changes from initial development, see [the Deprecations and Breaking Changes section](https://github.com/emmahsax/okcomputer/blob/3f6708b333ddaf7ecc14d8c2b163335d46343f66/README.markdown#deprecations-and-breaking-changes) of the pre 1.0 README.
+* For prior breaking changes from initial development, see [the Deprecations and Breaking Changes section](https://github.com/okcomputer-ruby/okcomputer/blob/3f6708b333ddaf7ecc14d8c2b163335d46343f66/README.markdown#deprecations-and-breaking-changes) of the pre 1.0 README.

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -199,5 +199,3 @@
 
 * Version bump
 * For prior breaking changes from initial development, see [the Deprecations and Breaking Changes section](https://github.com/okcomputer-ruby/okcomputer/blob/3f6708b333ddaf7ecc14d8c2b163335d46343f66/README.markdown#deprecations-and-breaking-changes) of the pre 1.0 README.
-
-git remote set-url origin git@github.com:okcomputer-ruby/okcomputer.git

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -199,3 +199,5 @@
 
 * Version bump
 * For prior breaking changes from initial development, see [the Deprecations and Breaking Changes section](https://github.com/okcomputer-ruby/okcomputer/blob/3f6708b333ddaf7ecc14d8c2b163335d46343f66/README.markdown#deprecations-and-breaking-changes) of the pre 1.0 README.
+
+git remote set-url origin git@github.com:okcomputer-ruby/okcomputer.git

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,8 @@
 #### Unreleased
+
+#### v1.19.2
+* Rename organization from `emmahsax` to `okcomputer-ruby`
+  > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/25
 * Use `actions/checkout@v6`
   > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/24
 * Replace Ruby 3.5 with Ruby 4.0 in all rspec tests

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,4 @@
 #### Unreleased
-
-#### v1.19.2
 * Rename organization from `emmahsax` to `okcomputer-ruby`
   > emmahsax: https://github.com/okcomputer-ruby/okcomputer/pull/25
 * Use `actions/checkout@v6`

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Emma Sax
+Copyright 2024 OkComputer (Ruby)
 Copyright 2017-2024 SportsEngine
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
 [![Gem Version](https://badge.fury.io/rb/okcomputer.svg)](https://badge.fury.io/rb/okcomputer)
 [![Downloads](https://img.shields.io/gem/dt/okcomputer.svg)](https://rubygems.org/gems/okcomputer)
-[![License](https://img.shields.io/github/license/emmahsax/okcomputer.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/okcomputer-ruby/okcomputer.svg)](LICENSE)
 [![Ruby Versions](https://img.shields.io/badge/Ruby-%3E%3D%202.1-brightgreen.svg)](https://www.ruby-lang.org)
-[![Build Status](https://github.com/emmahsax/okcomputer/actions/workflows/ci.yml/badge.svg)](https://github.com/emmahsax/okcomputer/actions/workflows/ci.yml)
+[![Build Status](https://github.com/okcomputer-ruby/okcomputer/actions/workflows/ci.yml/badge.svg)](https://github.com/okcomputer-ruby/okcomputer/actions/workflows/ci.yml)
 
 # OkComputer
 
@@ -185,7 +185,7 @@ This check will run and report its status, but will not affect the HTTP status c
 The plain-text output flows through Rails' internationalization framework.
 Adjust the output as necessary by defining `okcomputer.check.passed` and
 `okcomputer.check.failed` keys in your setup. The default values are available
-[in `okcomputer.en.yml`](https://github.com/emmahsax/okcomputer/blob/main/config/locales/okcomputer.en.yml).
+[in `okcomputer.en.yml`](https://github.com/okcomputer-ruby/okcomputer/blob/main/config/locales/okcomputer.en.yml).
 
 ## Running checks in parallel
 
@@ -247,12 +247,12 @@ bundle and run the tests with a specific version of Rails.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new pull request on upstream (this repository)
-6. Update [`CHANGELOG.markdown`](https://github.com/emmahsax/okcomputer/blob/main/CHANGELOG.markdown) under an `Unreleased` tag version (create a new one at the top if needed) with summarized changes and link to the pull request
+6. Update [`CHANGELOG.markdown`](https://github.com/okcomputer-ruby/okcomputer/blob/main/CHANGELOG.markdown) under an `Unreleased` tag version (create a new one at the top if needed) with summarized changes and link to the pull request
 
 ## Releasing
 
 1. Ensure you have push permissions to [RubyGems](https://rubygems.org/gems/okcomputer)
 2. Merge all PRs so that `main` is up to date with the new version
-3. Determine the new version ([`lib/ok_computer/version`](https://github.com/emmahsax/okcomputer/blob/main/lib/ok_computer/version.rb) has the current latest one) by following [semantic versioning](https://semver.org/) guidelines
+3. Determine the new version ([`lib/ok_computer/version`](https://github.com/okcomputer-ruby/okcomputer/blob/main/lib/ok_computer/version.rb) has the current latest one) by following [semantic versioning](https://semver.org/) guidelines
 4. Ensure you're on the `main` branch and you are locally up to date (`git checkout main && git pull`)
 5. Run the release script and pass in the new version (`bin/release vX.X.X`... the `v` at the beginning is optional)

--- a/okcomputer.gemspec
+++ b/okcomputer.gemspec
@@ -13,13 +13,12 @@ authors = {
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  username      = "emmahsax"
   s.name        = "okcomputer"
   s.version     = OkComputer::VERSION
   s.authors     = authors.keys
   s.email       = authors.values
   s.license     = "MIT"
-  s.homepage    = "https://github.com/#{username}/#{s.name}"
+  s.homepage    = "https://github.com/okcomputer-ruby/#{s.name}"
   s.summary     = "A simple, extensible health-check monitor"
   s.description = <<-EOL.strip
     Inspired by the simplicity of Fitter Happier, but frustrated by its lack of flexibility, we built OkComputer. Create and register your own custom health checks, or choose from the built-in library of checks to ensure your app is working as intended.


### PR DESCRIPTION
Update organization in gem to reflect new permanent organization (that's not individually owned).

Updates:
* Changelog URLs
* README URLs
* Gemspec configuration
* License attribution
* Adds concurrency limits to CI so that it cancels if there's a newer push (lots of tests run on each commit; this way we won't burn through free minutes on GHA)